### PR TITLE
Use listen address for config instead of host and port, with env override

### DIFF
--- a/services/r2ctl/config/server.go
+++ b/services/r2ctl/config/server.go
@@ -28,11 +28,8 @@ import (
 )
 
 type serverConfig struct {
-	// Host is the host name the HTTP server shoud listen on.
-	Host string `yaml:"host" validate:"nonzero"`
-
-	// Port is the port the HTTP server should listen on.
-	Port int `yaml:"port"`
+	// ListenAddress is the HTTP server listen address.
+	ListenAddress string `yaml:"listenAddress" validate:"nonzero"`
 
 	// ReadTimeout is the HTTP server read timeout.
 	ReadTimeout time.Duration `yaml:"readTimeout"`


### PR DESCRIPTION
This makes the config just like all our other services, and allows config to specify the listen address rather than splitting the host and the port out separately which is non-idiomatic.